### PR TITLE
Feature: Persistent book position API

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmConfigModule } from './modules/typeorm.module';
 import { BooksModule } from './modules/book.module';
 import { BookShelvesModule } from './modules/book-shelf.module';
 import { UsersModule } from './modules/user.module';
+import { SavedPositionsModule } from './modules/saved-position.module';
 import { HealthModule } from './modules/health.module';
 
 @Module({
@@ -23,6 +24,7 @@ import { HealthModule } from './modules/health.module';
     BooksModule,
     BookShelvesModule,
     UsersModule,
+    SavedPositionsModule,
   ],
   controllers: [],
   providers: [],

--- a/src/application/contracts/saved-position/delete-saved-position-request.ts
+++ b/src/application/contracts/saved-position/delete-saved-position-request.ts
@@ -1,0 +1,4 @@
+export class DeleteSavedPositionRequest {
+  bookId: string;
+  userId: string;
+}

--- a/src/application/contracts/saved-position/get-saved-position-request.ts
+++ b/src/application/contracts/saved-position/get-saved-position-request.ts
@@ -1,0 +1,4 @@
+export class GetSavedPositionRequest {
+  bookId: string;
+  userId: string;
+}

--- a/src/application/contracts/saved-position/get-saved-positions-request.ts
+++ b/src/application/contracts/saved-position/get-saved-positions-request.ts
@@ -1,0 +1,3 @@
+export class GetSavedPositionsRequest {
+  userId: string;
+}

--- a/src/application/contracts/saved-position/save-position-request.ts
+++ b/src/application/contracts/saved-position/save-position-request.ts
@@ -1,0 +1,6 @@
+export class SavePositionRequest {
+  bookId: string;
+  userId: string;
+  position: string;
+  deviceName: string;
+}

--- a/src/application/interfaces/saved-position-repository.ts
+++ b/src/application/interfaces/saved-position-repository.ts
@@ -1,0 +1,9 @@
+import { Result } from 'src/core/result';
+import { SavedPosition } from 'src/domain/entities/saved-position.entity';
+
+export interface ISavedPositionRepository {
+  findByBookAndUser(bookId: string, userId: string): Promise<Result<SavedPosition>>;
+  findAllByUser(userId: string): Promise<Result<SavedPosition[]>>;
+  upsert(savedPosition: SavedPosition): Promise<Result<SavedPosition>>;
+  delete(bookId: string, userId: string): Promise<Result<void>>;
+}

--- a/src/application/usecases/saved-position/delete-saved-position.usecase.ts
+++ b/src/application/usecases/saved-position/delete-saved-position.usecase.ts
@@ -1,0 +1,22 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ISavedPositionRepository } from '../../interfaces/saved-position-repository';
+import { DeleteSavedPositionRequest } from '../../contracts/saved-position/delete-saved-position-request';
+import { Result } from 'src/core/result';
+import { UseCase } from 'src/core/usecase';
+
+@Injectable()
+export class DeleteSavedPositionUseCase
+  implements UseCase<DeleteSavedPositionRequest, void>
+{
+  constructor(
+    @Inject('SavedPositionRepository')
+    private savedPositionRepository: ISavedPositionRepository,
+  ) {}
+
+  async execute({
+    bookId,
+    userId,
+  }: DeleteSavedPositionRequest): Promise<Result<void>> {
+    return await this.savedPositionRepository.delete(bookId, userId);
+  }
+}

--- a/src/application/usecases/saved-position/get-saved-position.usecase.ts
+++ b/src/application/usecases/saved-position/get-saved-position.usecase.ts
@@ -1,0 +1,23 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ISavedPositionRepository } from '../../interfaces/saved-position-repository';
+import { GetSavedPositionRequest } from '../../contracts/saved-position/get-saved-position-request';
+import { SavedPosition } from 'src/domain/entities/saved-position.entity';
+import { Result } from 'src/core/result';
+import { UseCase } from 'src/core/usecase';
+
+@Injectable()
+export class GetSavedPositionUseCase
+  implements UseCase<GetSavedPositionRequest, SavedPosition>
+{
+  constructor(
+    @Inject('SavedPositionRepository')
+    private savedPositionRepository: ISavedPositionRepository,
+  ) {}
+
+  async execute({
+    bookId,
+    userId,
+  }: GetSavedPositionRequest): Promise<Result<SavedPosition>> {
+    return await this.savedPositionRepository.findByBookAndUser(bookId, userId);
+  }
+}

--- a/src/application/usecases/saved-position/get-saved-positions.usecase.ts
+++ b/src/application/usecases/saved-position/get-saved-positions.usecase.ts
@@ -1,0 +1,22 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ISavedPositionRepository } from '../../interfaces/saved-position-repository';
+import { GetSavedPositionsRequest } from '../../contracts/saved-position/get-saved-positions-request';
+import { SavedPosition } from 'src/domain/entities/saved-position.entity';
+import { Result } from 'src/core/result';
+import { UseCase } from 'src/core/usecase';
+
+@Injectable()
+export class GetSavedPositionsUseCase
+  implements UseCase<GetSavedPositionsRequest, SavedPosition[]>
+{
+  constructor(
+    @Inject('SavedPositionRepository')
+    private savedPositionRepository: ISavedPositionRepository,
+  ) {}
+
+  async execute({
+    userId,
+  }: GetSavedPositionsRequest): Promise<Result<SavedPosition[]>> {
+    return await this.savedPositionRepository.findAllByUser(userId);
+  }
+}

--- a/src/application/usecases/saved-position/save-position.usecase.ts
+++ b/src/application/usecases/saved-position/save-position.usecase.ts
@@ -1,0 +1,27 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ISavedPositionRepository } from '../../interfaces/saved-position-repository';
+import { SavePositionRequest } from '../../contracts/saved-position/save-position-request';
+import { SavedPosition } from 'src/domain/entities/saved-position.entity';
+import { SavedPositionFactory } from 'src/domain/entities/saved-position.factory';
+import { Result } from 'src/core/result';
+import { UseCase } from 'src/core/usecase';
+
+@Injectable()
+export class SavePositionUseCase
+  implements UseCase<SavePositionRequest, SavedPosition>
+{
+  constructor(
+    @Inject('SavedPositionRepository')
+    private savedPositionRepository: ISavedPositionRepository,
+  ) {}
+
+  async execute(request: SavePositionRequest): Promise<Result<SavedPosition>> {
+    const savedPosition = SavedPositionFactory.create(
+      request.bookId,
+      request.userId,
+      request.position,
+      request.deviceName,
+    );
+    return await this.savedPositionRepository.upsert(savedPosition);
+  }
+}

--- a/src/domain/entities/saved-position.entity.ts
+++ b/src/domain/entities/saved-position.entity.ts
@@ -1,0 +1,10 @@
+export class SavedPosition {
+  constructor(
+    public bookId: string,
+    public userId: string,
+    public position: string,
+    public deviceName: string,
+    public createdAt: Date,
+    public updatedAt: Date,
+  ) {}
+}

--- a/src/domain/entities/saved-position.factory.ts
+++ b/src/domain/entities/saved-position.factory.ts
@@ -1,0 +1,26 @@
+import { SavedPosition } from 'src/domain/entities/saved-position.entity';
+
+export class SavedPositionFactory {
+  static create(
+    bookId: string,
+    userId: string,
+    position: string,
+    deviceName: string,
+    createdAt?: Date,
+    updatedAt?: Date,
+  ): SavedPosition {
+    if (!bookId || !userId) {
+      throw new Error('Book ID and User ID are required to create a saved position.');
+    }
+
+    const now = new Date();
+    return new SavedPosition(
+      bookId,
+      userId,
+      position,
+      deviceName,
+      createdAt ?? now,
+      updatedAt ?? now,
+    );
+  }
+}

--- a/src/domain/failures/saved-position.failures.ts
+++ b/src/domain/failures/saved-position.failures.ts
@@ -1,0 +1,7 @@
+import { Failure } from 'src/core/result';
+
+export class SavedPositionNotFoundFailure extends Failure {
+  constructor() {
+    super('NOT_FOUND', 'Saved position not found');
+  }
+}

--- a/src/infrastructure/database/saved-position.entity.ts
+++ b/src/infrastructure/database/saved-position.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { BookEntity } from 'src/infrastructure/database/book.entity';
+import { UserEntity } from 'src/infrastructure/database/user.entity';
+
+@Entity()
+export class SavedPositionEntity {
+  @PrimaryColumn('uuid', { name: 'book_id' })
+  bookId: string;
+
+  @PrimaryColumn('uuid', { name: 'user_id' })
+  userId: string;
+
+  @Column()
+  position: string;
+
+  @Column({ name: 'device_name' })
+  deviceName: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+
+  @ManyToOne(() => BookEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'book_id' })
+  book?: BookEntity;
+
+  @ManyToOne(() => UserEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user?: UserEntity;
+}

--- a/src/infrastructure/mappers/saved-position.mapper.ts
+++ b/src/infrastructure/mappers/saved-position.mapper.ts
@@ -1,0 +1,27 @@
+import { SavedPosition } from 'src/domain/entities/saved-position.entity';
+import { SavedPositionEntity } from 'src/infrastructure/database/saved-position.entity';
+import { SavedPositionFactory } from 'src/domain/entities/saved-position.factory';
+
+export class SavedPositionMapper {
+  static toDomain(entity: SavedPositionEntity): SavedPosition {
+    return SavedPositionFactory.create(
+      entity.bookId,
+      entity.userId,
+      entity.position,
+      entity.deviceName,
+      entity.createdAt,
+      entity.updatedAt,
+    );
+  }
+
+  static toPersistence(domain: SavedPosition): SavedPositionEntity {
+    const entity = new SavedPositionEntity();
+    entity.bookId = domain.bookId;
+    entity.userId = domain.userId;
+    entity.position = domain.position;
+    entity.deviceName = domain.deviceName;
+    entity.createdAt = domain.createdAt;
+    entity.updatedAt = domain.updatedAt;
+    return entity;
+  }
+}

--- a/src/infrastructure/repositories/saved-position.repository.ts
+++ b/src/infrastructure/repositories/saved-position.repository.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ISavedPositionRepository } from 'src/application/interfaces/saved-position-repository';
+import { SavedPositionEntity } from 'src/infrastructure/database/saved-position.entity';
+import { SavedPositionMapper } from 'src/infrastructure/mappers/saved-position.mapper';
+import { SavedPosition } from 'src/domain/entities/saved-position.entity';
+import { SavedPositionNotFoundFailure } from 'src/domain/failures/saved-position.failures';
+import { Result } from 'src/core/result';
+
+@Injectable()
+export class TypeOrmSavedPositionRepository
+  implements ISavedPositionRepository
+{
+  constructor(
+    @InjectRepository(SavedPositionEntity)
+    private repository: Repository<SavedPositionEntity>,
+  ) {}
+
+  async findAllByUser(userId: string): Promise<Result<SavedPosition[]>> {
+    const entities = await this.repository.find({
+      where: { userId },
+      order: { updatedAt: 'DESC' },
+    });
+    return Result.success(
+      entities.map((entity) => SavedPositionMapper.toDomain(entity)),
+    );
+  }
+
+  async findByBookAndUser(
+    bookId: string,
+    userId: string,
+  ): Promise<Result<SavedPosition>> {
+    const entity = await this.repository.findOne({
+      where: { bookId, userId },
+    });
+
+    if (!entity) {
+      return Result.failure(new SavedPositionNotFoundFailure());
+    }
+
+    return Result.success(SavedPositionMapper.toDomain(entity));
+  }
+
+  async upsert(savedPosition: SavedPosition): Promise<Result<SavedPosition>> {
+    const entity = SavedPositionMapper.toPersistence(savedPosition);
+    const saved = await this.repository.save(entity);
+    return Result.success(SavedPositionMapper.toDomain(saved));
+  }
+
+  async delete(bookId: string, userId: string): Promise<Result<void>> {
+    const result = await this.repository.delete({ bookId, userId });
+
+    if (result.affected === 0) {
+      return Result.failure(new SavedPositionNotFoundFailure());
+    }
+
+    return Result.success(undefined);
+  }
+}

--- a/src/migrations/1755566512419-AddSavedPositionsTable.ts
+++ b/src/migrations/1755566512419-AddSavedPositionsTable.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSavedPositionsTable1755566512419 implements MigrationInterface {
+  name = 'AddSavedPositionsTable1755566512419';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "saved_position_entity" (
+        "book_id" uuid NOT NULL,
+        "user_id" uuid NOT NULL,
+        "position" character varying NOT NULL,
+        "device_name" character varying NOT NULL,
+        "created_at" TIMESTAMP NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_saved_position_entity" PRIMARY KEY ("book_id", "user_id")
+      )`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "saved_position_entity" ADD CONSTRAINT "FK_saved_position_book" FOREIGN KEY ("book_id") REFERENCES "book_entity"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "saved_position_entity" ADD CONSTRAINT "FK_saved_position_user" FOREIGN KEY ("user_id") REFERENCES "user_entity"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "saved_position_entity" DROP CONSTRAINT "FK_saved_position_user"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "saved_position_entity" DROP CONSTRAINT "FK_saved_position_book"`,
+    );
+    await queryRunner.query(`DROP TABLE "saved_position_entity"`);
+  }
+}

--- a/src/modules/saved-position.module.ts
+++ b/src/modules/saved-position.module.ts
@@ -1,0 +1,34 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SavedPositionEntity } from 'src/infrastructure/database/saved-position.entity';
+import { TypeOrmSavedPositionRepository } from 'src/infrastructure/repositories/saved-position.repository';
+import { GetSavedPositionsUseCase } from 'src/application/usecases/saved-position/get-saved-positions.usecase';
+import { GetSavedPositionUseCase } from 'src/application/usecases/saved-position/get-saved-position.usecase';
+import { SavePositionUseCase } from 'src/application/usecases/saved-position/save-position.usecase';
+import { DeleteSavedPositionUseCase } from 'src/application/usecases/saved-position/delete-saved-position.usecase';
+import { SavedPositionMapper } from 'src/infrastructure/mappers/saved-position.mapper';
+import { SavedPositionController } from 'src/presentation/controllers/saved-position.controller';
+import { AuthModule } from 'src/modules/auth.module';
+import { UsersModule } from 'src/modules/user.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([SavedPositionEntity]),
+    AuthModule,
+    forwardRef(() => UsersModule),
+  ],
+  providers: [
+    {
+      provide: 'SavedPositionRepository',
+      useClass: TypeOrmSavedPositionRepository,
+    },
+    GetSavedPositionsUseCase,
+    GetSavedPositionUseCase,
+    SavePositionUseCase,
+    DeleteSavedPositionUseCase,
+    SavedPositionMapper,
+  ],
+  controllers: [SavedPositionController],
+  exports: ['SavedPositionRepository'],
+})
+export class SavedPositionsModule {}

--- a/src/modules/typeorm.module.ts
+++ b/src/modules/typeorm.module.ts
@@ -6,9 +6,11 @@ import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 import { BookShelfEntity } from '../infrastructure/database/book-shelf.entity';
 import { UserEntity } from '../infrastructure/database/user.entity';
 import { RoleEntity } from '../infrastructure/database/role.entity';
+import { SavedPositionEntity } from '../infrastructure/database/saved-position.entity';
 import { SchemaUpdate1755566512418 } from '../migrations/1755566512418-schema-update';
 import { AddUserAndRoleTables1739836800000 } from '../migrations/1739836800000-AddUserAndRoleTables';
 import { SeedAdminRole1739836800001 } from '../migrations/1739836800001-SeedAdminRole';
+import { AddSavedPositionsTable1755566512419 } from '../migrations/1755566512419-AddSavedPositionsTable';
 
 @Module({
   imports: [
@@ -45,11 +47,12 @@ import { SeedAdminRole1739836800001 } from '../migrations/1739836800001-SeedAdmi
           username: username,
           password: password,
           database: database,
-          entities: [BookEntity, BookShelfEntity, UserEntity, RoleEntity],
+          entities: [BookEntity, BookShelfEntity, UserEntity, RoleEntity, SavedPositionEntity],
           migrations: [
             SchemaUpdate1755566512418,
             AddUserAndRoleTables1739836800000,
             SeedAdminRole1739836800001,
+            AddSavedPositionsTable1755566512419,
           ],
           migrationsRun: true,
           migrationsTableName: 'migration_table',

--- a/src/presentation/controllers/saved-position.controller.ts
+++ b/src/presentation/controllers/saved-position.controller.ts
@@ -1,0 +1,67 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  Put,
+  Req,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { JwtAuthGuard } from 'src/infrastructure/guards/jwt-auth.guard';
+import { MapResultInterceptor } from '../interceptors/map_result.interceptor';
+import { GetSavedPositionsUseCase } from 'src/application/usecases/saved-position/get-saved-positions.usecase';
+import { GetSavedPositionUseCase } from 'src/application/usecases/saved-position/get-saved-position.usecase';
+import { SavePositionUseCase } from 'src/application/usecases/saved-position/save-position.usecase';
+import { DeleteSavedPositionUseCase } from 'src/application/usecases/saved-position/delete-saved-position.usecase';
+import { SavePositionDto } from '../dtos/save-position.dto';
+import { Request } from 'express';
+
+@Controller('users/:userId/saved-positions')
+@UseInterceptors(MapResultInterceptor)
+@UseGuards(JwtAuthGuard)
+export class SavedPositionController {
+  constructor(
+    private readonly getSavedPositionsUseCase: GetSavedPositionsUseCase,
+    private readonly getSavedPositionUseCase: GetSavedPositionUseCase,
+    private readonly savePositionUseCase: SavePositionUseCase,
+    private readonly deleteSavedPositionUseCase: DeleteSavedPositionUseCase,
+  ) {}
+
+  @Get()
+  getSavedPositions(@Req() req: Request) {
+    const userId = req['user'].id;
+    return this.getSavedPositionsUseCase.execute({ userId });
+  }
+
+  @Get(':bookId')
+  getSavedPosition(@Req() req: Request, @Param('bookId') bookId: string) {
+    const userId = req['user'].id;
+    return this.getSavedPositionUseCase.execute({ bookId, userId });
+  }
+
+  @Put(':bookId')
+  @HttpCode(204)
+  savePosition(
+    @Req() req: Request,
+    @Param('bookId') bookId: string,
+    @Body() dto: SavePositionDto,
+  ) {
+    const userId = req['user'].id;
+    return this.savePositionUseCase.execute({
+      bookId,
+      userId,
+      position: dto.position,
+      deviceName: dto.deviceName,
+    });
+  }
+
+  @Delete(':bookId')
+  @HttpCode(204)
+  deleteSavedPosition(@Req() req: Request, @Param('bookId') bookId: string) {
+    const userId = req['user'].id;
+    return this.deleteSavedPositionUseCase.execute({ bookId, userId });
+  }
+}

--- a/src/presentation/dtos/save-position.dto.ts
+++ b/src/presentation/dtos/save-position.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class SavePositionDto {
+  @IsNotEmpty({ message: 'Position is required' })
+  @IsString({ message: 'Invalid position' })
+  position: string;
+
+  @IsNotEmpty({ message: 'Device name is required' })
+  @IsString({ message: 'Invalid device name' })
+  deviceName: string;
+}


### PR DESCRIPTION
## Summary
- Add saved positions table with composite PK (book_id, user_id) and foreign keys to books/users
- Implement CRUD endpoints at `GET/PUT/DELETE /users/:userId/saved-positions/:bookId` and `GET /users/:userId/saved-positions`
- All endpoints protected by JWT auth guard, using authenticated user ID from token
- PUT uses upsert for idempotent position updates

## Endpoints
| Method | Path | Status | Description |
|--------|------|--------|-------------|
| GET | `/users/:userId/saved-positions` | 200 | List all saved positions |
| GET | `/users/:userId/saved-positions/:bookId` | 200 / 404 | Get saved position |
| PUT | `/users/:userId/saved-positions/:bookId` | 204 | Upsert position |
| DELETE | `/users/:userId/saved-positions/:bookId` | 204 / 404 | Delete position |

## Test plan
- [ ] Verify migration runs on fresh database without errors
- [ ] Test GET returns 404 when no position exists
- [ ] Test PUT creates a new position, then updates on subsequent calls
- [ ] Test GET returns saved position after PUT
- [ ] Test DELETE removes position and returns 404 on subsequent GET
- [ ] Test GET (list) returns all positions for authenticated user
- [ ] Verify auth guard rejects unauthenticated requests

Closes #14