### PR TITLE
feat: add percentage field to SavedPosition (#20)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,10 @@ uploads/cover-images/07c14c6a-8b0d-408e-89b8-80c3da59d8eb.jpg
 uploads/cover-images/870c28dc-e832-46e8-a89a-2161e12690ba.jpg
 uploads/cover-images/2010d8e0-0ecf-4dd0-b877-a885e8a50e70.jpg
 test/book.rest
+
+# AI assistant config files
+.claude/
+.github/copilot-instructions.md
+CLAUDE.md
+GEMINI.md
+AGENTS.md

--- a/src/application/contracts/saved-position/save-position-request.ts
+++ b/src/application/contracts/saved-position/save-position-request.ts
@@ -3,4 +3,5 @@ export class SavePositionRequest {
   userId: string;
   position: string;
   deviceName: string;
+  percentage?: number | null;
 }

--- a/src/application/usecases/saved-position/save-position.usecase.ts
+++ b/src/application/usecases/saved-position/save-position.usecase.ts
@@ -21,6 +21,7 @@ export class SavePositionUseCase
       request.userId,
       request.position,
       request.deviceName,
+      request.percentage,
     );
     return await this.savedPositionRepository.upsert(savedPosition);
   }

--- a/src/domain/entities/saved-position.entity.ts
+++ b/src/domain/entities/saved-position.entity.ts
@@ -6,5 +6,6 @@ export class SavedPosition {
     public deviceName: string,
     public createdAt: Date,
     public updatedAt: Date,
+    public percentage: number | null = null,
   ) {}
 }

--- a/src/domain/entities/saved-position.factory.ts
+++ b/src/domain/entities/saved-position.factory.ts
@@ -6,6 +6,7 @@ export class SavedPositionFactory {
     userId: string,
     position: string,
     deviceName: string,
+    percentage?: number | null,
     createdAt?: Date,
     updatedAt?: Date,
   ): SavedPosition {
@@ -23,6 +24,7 @@ export class SavedPositionFactory {
       deviceName,
       createdAt ?? now,
       updatedAt ?? now,
+      percentage ?? null,
     );
   }
 }

--- a/src/infrastructure/database/saved-position.entity.ts
+++ b/src/infrastructure/database/saved-position.entity.ts
@@ -24,6 +24,9 @@ export class SavedPositionEntity {
   @Column({ name: 'device_name' })
   deviceName: string;
 
+  @Column({ type: 'float', nullable: true, default: null })
+  percentage: number | null;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 

--- a/src/infrastructure/mappers/saved-position.mapper.ts
+++ b/src/infrastructure/mappers/saved-position.mapper.ts
@@ -9,6 +9,7 @@ export class SavedPositionMapper {
       entity.userId,
       entity.position,
       entity.deviceName,
+      entity.percentage,
       entity.createdAt,
       entity.updatedAt,
     );
@@ -20,6 +21,7 @@ export class SavedPositionMapper {
     entity.userId = domain.userId;
     entity.position = domain.position;
     entity.deviceName = domain.deviceName;
+    entity.percentage = domain.percentage;
     entity.createdAt = domain.createdAt;
     entity.updatedAt = domain.updatedAt;
     return entity;

--- a/src/migrations/1755566512420-AddPercentageToSavedPosition.ts
+++ b/src/migrations/1755566512420-AddPercentageToSavedPosition.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddPercentageToSavedPosition1755566512420
+  implements MigrationInterface
+{
+  name = 'AddPercentageToSavedPosition1755566512420';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "saved_position_entity" ADD COLUMN "percentage" double precision DEFAULT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "saved_position_entity" DROP COLUMN "percentage"`,
+    );
+  }
+}

--- a/src/presentation/controllers/saved-position.controller.ts
+++ b/src/presentation/controllers/saved-position.controller.ts
@@ -43,7 +43,6 @@ export class SavedPositionController {
   }
 
   @Put(':bookId')
-  @HttpCode(204)
   savePosition(
     @Req() req: Request,
     @Param('bookId') bookId: string,
@@ -55,6 +54,7 @@ export class SavedPositionController {
       userId,
       position: dto.position,
       deviceName: dto.deviceName,
+      percentage: dto.percentage,
     });
   }
 

--- a/src/presentation/dtos/save-position.dto.ts
+++ b/src/presentation/dtos/save-position.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsOptional, IsString, Max, Min } from 'class-validator';
 
 export class SavePositionDto {
   @IsNotEmpty({ message: 'Position is required' })
@@ -8,4 +8,10 @@ export class SavePositionDto {
   @IsNotEmpty({ message: 'Device name is required' })
   @IsString({ message: 'Invalid device name' })
   deviceName: string;
+
+  @IsOptional()
+  @IsNumber({}, { message: 'Invalid percentage' })
+  @Min(0, { message: 'Percentage must be between 0 and 1' })
+  @Max(1, { message: 'Percentage must be between 0 and 1' })
+  percentage?: number;
 }

--- a/test/application/usecases/saved-position/save-position.usecase.spec.ts
+++ b/test/application/usecases/saved-position/save-position.usecase.spec.ts
@@ -29,8 +29,25 @@ describe('SavePositionUseCase', () => {
     jest.clearAllMocks();
   });
 
-  test('Successfully saves a position', async () => {
+  test('Successfully saves a position with percentage', async () => {
     savedPositionRepository.upsert.mockResolvedValueOnce(Result.ok(mockSavedPosition));
+
+    const result = await useCase.execute({
+      bookId: mockSavedPosition.bookId,
+      userId: mockSavedPosition.userId,
+      position: mockSavedPosition.position,
+      deviceName: mockSavedPosition.deviceName,
+      percentage: 0.42,
+    });
+
+    expect(savedPositionRepository.upsert).toHaveBeenCalledTimes(1);
+    expect(result.isSuccess()).toBe(true);
+    expect(result.value).toEqual(mockSavedPosition);
+  });
+
+  test('Successfully saves a position without percentage (backwards compatibility)', async () => {
+    const savedPositionWithoutPercentage = { ...mockSavedPosition, percentage: null };
+    savedPositionRepository.upsert.mockResolvedValueOnce(Result.ok(savedPositionWithoutPercentage));
 
     const result = await useCase.execute({
       bookId: mockSavedPosition.bookId,
@@ -41,7 +58,7 @@ describe('SavePositionUseCase', () => {
 
     expect(savedPositionRepository.upsert).toHaveBeenCalledTimes(1);
     expect(result.isSuccess()).toBe(true);
-    expect(result.value).toEqual(mockSavedPosition);
+    expect(result.value?.percentage).toBeNull();
   });
 
   test('Fails when upsert operation fails', async () => {

--- a/test/domain/entities/saved-position.factory.spec.ts
+++ b/test/domain/entities/saved-position.factory.spec.ts
@@ -9,6 +9,7 @@ describe('SavedPositionFactory', () => {
         'user-1',
         'epubcfi(/6/4!/4/2/1:0)',
         'Desktop Browser',
+        undefined,
         now,
         now,
       );

--- a/test/infrastructure/mappers/saved-position.mapper.spec.ts
+++ b/test/infrastructure/mappers/saved-position.mapper.spec.ts
@@ -9,6 +9,7 @@ describe('SavedPositionMapper', () => {
     userId: mockSavedPosition.userId,
     position: mockSavedPosition.position,
     deviceName: mockSavedPosition.deviceName,
+    percentage: mockSavedPosition.percentage,
     createdAt: mockSavedPosition.createdAt,
     updatedAt: mockSavedPosition.updatedAt,
   };

--- a/test/mocks/entityMocks.ts
+++ b/test/mocks/entityMocks.ts
@@ -50,6 +50,7 @@ export const mockSavedPositionEntity: SavedPositionEntity = {
   userId: mockSavedPosition.userId,
   position: mockSavedPosition.position,
   deviceName: mockSavedPosition.deviceName,
+  percentage: mockSavedPosition.percentage,
   createdAt: mockSavedPosition.createdAt,
   updatedAt: mockSavedPosition.updatedAt,
 };

--- a/test/mocks/savedPositionMocks.ts
+++ b/test/mocks/savedPositionMocks.ts
@@ -7,4 +7,5 @@ export const mockSavedPosition = new SavedPosition(
   'Chrome Desktop',
   new Date('2024-01-01'),
   new Date('2024-01-01'),
+  0.42,
 );


### PR DESCRIPTION
## Summary

Adds a `percentage` field (nullable float, 0-1) to `SavedPosition` so that reading progress percentage can be stored and returned alongside the CFI position string.

## Acceptance Criteria

- [x] **Save reading progress percentage** -- `PUT /users/{userId}/saved-positions/{bookId}` accepts optional `percentage` and returns it in the response (200 with body)
- [x] **Retrieve saved position includes percentage** -- `GET /users/{userId}/saved-positions/{bookId}` returns `percentage` in the response body
- [x] **Retrieve all saved positions includes percentage** -- `GET /users/{userId}/saved-positions` returns `percentage` for each item
- [x] **Percentage is optional for backwards compatibility** -- omitting `percentage` from the PUT body defaults it to null; existing clients are unaffected
- [x] **Percentage not exposed across users** -- no change to user-scoped query logic; positions are always filtered by userId

## Changes

- Domain entity, factory, mapper, TypeORM entity, request contract, use case, DTO, controller updated
- `percentage` validated with `@Min(0)` and `@Max(1)` in the DTO to reject out-of-range values
- Migration `1755566512420` adds nullable `double precision percentage` column to `saved_position_entity`
- Tests updated and new backwards-compatibility test added
