### PR TITLE
feat: add summary field to book entity and API (#26)

### DIFF
--- a/src/application/contracts/book/create-book-request.ts
+++ b/src/application/contracts/book/create-book-request.ts
@@ -23,4 +23,8 @@ export class CreateBookRequest {
   @IsOptional()
   @IsString()
   coverImageFileName?: string;
+
+  @IsOptional()
+  @IsString()
+  summary?: string;
 }

--- a/src/application/contracts/book/update-book-request.ts
+++ b/src/application/contracts/book/update-book-request.ts
@@ -18,4 +18,8 @@ export class UpdateBookRequest {
 
   @IsOptional()
   isFavorite?: boolean;
+
+  @IsOptional()
+  @IsString()
+  summary?: string;
 }

--- a/src/application/usecases/book/create-book.usecase.ts
+++ b/src/application/usecases/book/create-book.usecase.ts
@@ -23,6 +23,7 @@ export class CreateBookUseCase implements UseCase<CreateBookRequest, Book> {
       dto.isFavorite ?? false,
       dto.publishedYear ? this._parseYear(dto.publishedYear) : undefined,
       dto.coverImageFileName,
+      dto.summary,
     );
     return await this.bookRepository.create(book);
   }

--- a/src/application/usecases/book/update-book.usecase.ts
+++ b/src/application/usecases/book/update-book.usecase.ts
@@ -23,6 +23,7 @@ export class UpdateBookUseCase implements UseCase<UpdateBookRequest, Book> {
     book.author = request.author ?? book.author;
     book.isFavorite = request.isFavorite ?? book.isFavorite;
     book.publishedYear = request.publishedYear ?? book.publishedYear;
+    book.summary = request.summary !== undefined ? request.summary : book.summary;
 
     return await this.bookRepository.update(request.id, book);
   }

--- a/src/domain/entities/book.entity.ts
+++ b/src/domain/entities/book.entity.ts
@@ -7,5 +7,6 @@ export class Book {
     public isFavorite: boolean,
     public publishedYear?: number,
     public coverImageFileName?: string,
+    public summary?: string,
   ) {}
 }

--- a/src/domain/entities/book.factory.ts
+++ b/src/domain/entities/book.factory.ts
@@ -9,6 +9,7 @@ export class BookFactory {
     isFavorite: boolean = false,
     publishedYear?: number,
     coverImageFileName?: string,
+    summary?: string,
   ): Book {
     if (!title || !author) {
       throw new Error('Title and author are required to create a book.');
@@ -22,6 +23,7 @@ export class BookFactory {
       isFavorite,
       publishedYear,
       coverImageFileName,
+      summary,
     );
   }
 }

--- a/src/infrastructure/database/book.entity.ts
+++ b/src/infrastructure/database/book.entity.ts
@@ -24,6 +24,9 @@ export class BookEntity {
   @Column({ name: 'cover_image_file_name', nullable: true })
   coverImageFileName?: string;
 
+  @Column({ type: 'text', nullable: true, default: null })
+  summary?: string;
+
   @ManyToMany(() => BookShelfEntity, (bookShelf) => bookShelf.books)
   bookShelves?: BookShelfEntity[];
 }

--- a/src/infrastructure/mappers/book.mapper.ts
+++ b/src/infrastructure/mappers/book.mapper.ts
@@ -12,6 +12,7 @@ export class BookMapper {
       bookEntity.isFavorite,
       bookEntity.publishedYear,
       bookEntity.coverImageFileName,
+      bookEntity.summary,
     );
   }
 
@@ -24,6 +25,7 @@ export class BookMapper {
       isFavorite: book.isFavorite,
       publishedYear: book.publishedYear,
       coverImageFileName: book.coverImageFileName,
+      summary: book.summary,
     };
   }
 

--- a/src/migrations/1755566512421-AddSummaryToBook.ts
+++ b/src/migrations/1755566512421-AddSummaryToBook.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSummaryToBook1755566512421 implements MigrationInterface {
+  name = 'AddSummaryToBook1755566512421';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "book_entity" ADD COLUMN "summary" text DEFAULT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "book_entity" DROP COLUMN "summary"`,
+    );
+  }
+}

--- a/src/presentation/dtos/update-book.dto.ts
+++ b/src/presentation/dtos/update-book.dto.ts
@@ -3,4 +3,5 @@ export interface UpdateBookDto {
   author?: string;
   isFavorite?: boolean;
   publishedYear?: number;
+  summary?: string;
 }

--- a/test/application/usecases/book/create-book.usecase.spec.ts
+++ b/test/application/usecases/book/create-book.usecase.spec.ts
@@ -118,6 +118,37 @@ describe('CreateBookUseCase', () => {
     expect(calledWith.isFavorite).toBe(true);
   });
 
+  test('Successfully creates a book with a summary', async () => {
+    bookRepository.create.mockResolvedValueOnce(Result.ok(mockBook));
+
+    const result = await useCase.execute({
+      title: 'Test Book',
+      author: 'Test Author',
+      fileName: 'test-book.epub',
+      summary: 'A test book summary.',
+    });
+
+    expect(result.isSuccess()).toBe(true);
+
+    const calledWith = bookRepository.create.mock.calls[0][0];
+    expect(calledWith.summary).toBe('A test book summary.');
+  });
+
+  test('Successfully creates a book without a summary', async () => {
+    bookRepository.create.mockResolvedValueOnce(Result.ok(mockBook));
+
+    const result = await useCase.execute({
+      title: 'Test Book',
+      author: 'Test Author',
+      fileName: 'test-book.epub',
+    });
+
+    expect(result.isSuccess()).toBe(true);
+
+    const calledWith = bookRepository.create.mock.calls[0][0];
+    expect(calledWith.summary).toBeUndefined();
+  });
+
   test('Fails when repository create fails', async () => {
     const error = new UnexpectedFailure('Database error');
     bookRepository.create.mockResolvedValueOnce(Result.fail(error));

--- a/test/application/usecases/book/update-book.usecase.spec.ts
+++ b/test/application/usecases/book/update-book.usecase.spec.ts
@@ -90,6 +90,22 @@ describe('UpdateBookUseCase', () => {
     expect(result.value!.isFavorite).toBe(true);
   });
 
+  test('Successfully updates a book summary', async () => {
+    const updatedBook = { ...mockBook, summary: 'Updated summary.' };
+    bookRepository.findById.mockResolvedValueOnce(Result.ok(mockBook));
+    bookRepository.update.mockResolvedValueOnce(Result.ok(updatedBook));
+
+    const result = await useCase.execute({
+      id: mockBook.id,
+      summary: 'Updated summary.',
+    });
+
+    expect(bookRepository.findById).toHaveBeenCalledTimes(1);
+    expect(bookRepository.update).toHaveBeenCalledTimes(1);
+    expect(result.isSuccess()).toBe(true);
+    expect(result.value!.summary).toBe('Updated summary.');
+  });
+
   test('Fails when book not found', async () => {
     bookRepository.findById.mockResolvedValueOnce(Result.fail(bookNotFoundFailure));
 

--- a/test/mocks/bookMocks.ts
+++ b/test/mocks/bookMocks.ts
@@ -8,6 +8,7 @@ export const mockBook: Book = new Book(
   false,
   2001,
   'test-cover.jpg',
+  'A test book summary.',
 );
 
 export const mockBookFavorite: Book = new Book(
@@ -18,4 +19,5 @@ export const mockBookFavorite: Book = new Book(
   true,
   2023,
   'favorite-cover.jpg',
+  undefined,
 );


### PR DESCRIPTION
## Summary

Adds an optional `summary` field to the book entity, persisted as a nullable `text` column. The summary is accepted on `POST /books` and `PUT /books/:id`, and returned in all book response objects.

## Acceptance Criteria

- ✅ **Uploading a book with a summary** — `POST /books` accepts `summary` in the multipart body and persists it; `GET /books/:id` returns the `summary` field.
- ✅ **Uploading a book without a summary** — `POST /books` without `summary` saves the book with null summary; `GET /books/:id` returns summary as absent/null.
- ✅ **Existing books pre-dating the summary field** — Migration adds nullable column with default null, so existing rows are unaffected; `GET /books/:id` and `GET /books` still return them successfully with `summary` absent/null.
- ✅ **Updating a book summary** — `PUT /books/:id` with `summary` updates the field; subsequent `GET /books/:id` returns the updated summary.
- ✅ **Authentication required** — All `/books` endpoints are guarded by `JwtAuthGuard` (pre-existing, unchanged).
- ✅ **User data isolation** — Repository-level user scoping is pre-existing and unchanged.

## Changes

- `src/domain/entities/book.entity.ts` — Added `summary?: string` to `Book` constructor
- `src/domain/entities/book.factory.ts` — Added `summary` parameter to `BookFactory.create()`
- `src/infrastructure/database/book.entity.ts` — Added `@Column({ type: 'text', nullable: true })` for `summary`
- `src/infrastructure/mappers/book.mapper.ts` — Pass `summary` through `toDomain()` and `toPersistence()`
- `src/application/contracts/book/create-book-request.ts` — Added optional `summary` field
- `src/application/contracts/book/update-book-request.ts` — Added optional `summary` field
- `src/presentation/dtos/update-book.dto.ts` — Added optional `summary` field
- `src/application/usecases/book/create-book.usecase.ts` — Pass `summary` to `BookFactory.create()`
- `src/application/usecases/book/update-book.usecase.ts` — Merge `summary` on update
- `src/migrations/1755566512421-AddSummaryToBook.ts` — New migration adding `summary text DEFAULT NULL` to `book_entity`
- `test/mocks/bookMocks.ts` — Added `summary` to `mockBook`; explicit `undefined` to `mockBookFavorite`
- `test/.../create-book.usecase.spec.ts` — Added tests for creating with/without summary
- `test/.../update-book.usecase.spec.ts` — Added test for updating summary

Closes #26
