### PR TITLE
fix: support TypeORM migrations in production Docker container (#7)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,6 @@ WORKDIR /usr/src/app
 COPY --from=dependencies /usr/src/app/node_modules ./node_modules
 COPY --from=build /usr/src/app/dist ./dist
 COPY package*.json ./
-COPY ./src/data-source.ts /usr/src/app/src/data-source.ts
-COPY ./src/migrations /usr/src/app/src/migrations
 
 EXPOSE 3000
 CMD ["node", "dist/main"]

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -16,8 +16,8 @@ export default new DataSource({
   logging: false,
   logger: 'file',
   entities: ['dist/**/*.entity{.ts,.js}'],
-  migrations: ['src/migrations/**/*.ts'],
-  subscribers: ['src/subscriber/**/*.ts'],
+  migrations: ['dist/migrations/**/*.js'],
+  subscribers: ['dist/subscriber/**/*.js'],
   migrationsTableName: 'migration_table',
   namingStrategy: new SnakeNamingStrategy(),
 });

--- a/src/modules/typeorm.module.ts
+++ b/src/modules/typeorm.module.ts
@@ -14,6 +14,7 @@ import { SeedAdminRole1739836800001 } from '../migrations/1739836800001-SeedAdmi
 import { AddSavedPositionsTable1755566512419 } from '../migrations/1755566512419-AddSavedPositionsTable';
 import { AddPercentageToSavedPosition1755566512420 } from '../migrations/1755566512420-AddPercentageToSavedPosition';
 import { AddAuthorTable1740614850000 } from '../migrations/1740614850000-AddAuthorTable';
+import { AddSummaryToBook1755566512421 } from '../migrations/1755566512421-AddSummaryToBook';
 
 @Module({
   imports: [
@@ -65,6 +66,7 @@ import { AddAuthorTable1740614850000 } from '../migrations/1740614850000-AddAuth
             AddSavedPositionsTable1755566512419,
             AddPercentageToSavedPosition1755566512420,
             AddAuthorTable1740614850000,
+            AddSummaryToBook1755566512421,
           ],
           migrationsRun: true,
           migrationsTableName: 'migration_table',


### PR DESCRIPTION
## Summary

Fixes the production Dockerfile so TypeORM migrations work correctly in a container environment.

## Changes

### Dockerfile
Removed two lines that copied TypeScript source files (src/data-source.ts and src/migrations/) into the production stage. These files cannot be executed without 	s-node, which is not available in the production image. Migrations are already handled automatically on application startup via migrationsRun: true in TypeOrmModule.forRootAsync — the TS copies served no purpose.

### src/data-source.ts
Updated migrations and subscribers paths from src/**/*.ts to dist/**/*.js. The compiled dist/data-source.js is already present in the production image (via the existing COPY --from=build) and now correctly references compiled migration files.

### src/modules/typeorm.module.ts
Added the missing AddSummaryToBook1755566512421 migration to the migrations array. This migration was introduced in the eat/add-book-summary PR but was not registered in the module, so it was never running on container startup.

## Acceptance Criteria

- ✅ Production Docker image no longer copies unreachable TypeScript source files
- ✅ Migrations run automatically on container startup via migrationsRun: true
- ✅ src/data-source.ts references compiled JS paths for CLI tooling
- ✅ All existing migrations (including AddSummaryToBook) are registered and will run

Closes #7
