### PR TITLE
feat: fetch book summary from Open Library API on upload

### DIFF
--- a/src/application/contracts/book/create-book-request.ts
+++ b/src/application/contracts/book/create-book-request.ts
@@ -23,8 +23,4 @@ export class CreateBookRequest {
   @IsOptional()
   @IsString()
   coverImageFileName?: string;
-
-  @IsOptional()
-  @IsString()
-  summary?: string;
 }

--- a/src/application/usecases/book/fetch-book-summary.usecase.ts
+++ b/src/application/usecases/book/fetch-book-summary.usecase.ts
@@ -1,0 +1,40 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { IBookRepository } from '../../interfaces/book-repository';
+import { Book } from 'src/domain/entities/book.entity';
+import { Result } from 'src/core/result';
+import { UseCase } from 'src/core/usecase';
+import { OpenLibraryGateway } from 'src/infrastructure/gateways/open-library.gateway';
+
+export interface FetchBookSummaryRequest {
+  id: string;
+}
+
+@Injectable()
+export class FetchBookSummaryUseCase
+  implements UseCase<FetchBookSummaryRequest, Book>
+{
+  constructor(
+    @Inject('BookRepository') private bookRepository: IBookRepository,
+    private openLibraryGateway: OpenLibraryGateway,
+  ) {}
+
+  async execute(request: FetchBookSummaryRequest): Promise<Result<Book>> {
+    const findResult = await this.bookRepository.findById(request.id);
+    if (!findResult.isSuccess()) {
+      return findResult;
+    }
+
+    const book = findResult.value;
+    const summary = await this.openLibraryGateway.findBookSummary(
+      book.title,
+      book.author,
+    );
+
+    if (summary === null) {
+      return findResult;
+    }
+
+    book.summary = summary;
+    return await this.bookRepository.update(request.id, book);
+  }
+}

--- a/src/infrastructure/gateways/open-library.gateway.ts
+++ b/src/infrastructure/gateways/open-library.gateway.ts
@@ -1,5 +1,21 @@
 import { Injectable, Logger } from '@nestjs/common';
 
+interface BookSummarySearchDoc {
+  key: string;
+}
+
+interface BookSummarySearchResponse {
+  docs: BookSummarySearchDoc[];
+}
+
+interface OpenLibraryDescriptionObject {
+  value: string;
+}
+
+interface OpenLibraryWorkResponse {
+  description?: string | OpenLibraryDescriptionObject;
+}
+
 interface AuthorEnrichment {
   biography: string | null;
   photoUrl: string | null;
@@ -32,11 +48,67 @@ export class OpenLibraryGateway {
   private readonly logger = new Logger(OpenLibraryGateway.name);
   private readonly baseUrl = 'https://openlibrary.org';
   private readonly coversUrl = 'https://covers.openlibrary.org';
-  private readonly userAgent = 'Homebranch (self-hosted e-book library)';
+  private readonly userAgent = 'Homebranch (self-hosted e-book library; ryan.bezold@gmail.com)';
   private readonly timeoutMs = 8000;
 
   private createAbortSignal(): AbortSignal {
     return AbortSignal.timeout(this.timeoutMs);
+  }
+
+  async findBookSummary(
+    title: string,
+    author: string,
+  ): Promise<string | null> {
+    try {
+      const searchUrl = `${this.baseUrl}/search.json?title=${encodeURIComponent(title)}&author=${encodeURIComponent(author)}&limit=1&fields=key`;
+      const searchResponse = await fetch(searchUrl, {
+        headers: { 'User-Agent': this.userAgent },
+        signal: this.createAbortSignal(),
+      });
+
+      if (!searchResponse.ok) {
+        return null;
+      }
+
+      const searchData =
+        (await searchResponse.json()) as BookSummarySearchResponse;
+
+      if (!searchData.docs || searchData.docs.length === 0) {
+        return null;
+      }
+
+      const workKey = searchData.docs[0].key;
+      const workUrl = `${this.baseUrl}${workKey}.json`;
+      const workResponse = await fetch(workUrl, {
+        headers: { 'User-Agent': this.userAgent },
+        signal: this.createAbortSignal(),
+      });
+
+      if (!workResponse.ok) {
+        return null;
+      }
+
+      const workData = (await workResponse.json()) as OpenLibraryWorkResponse;
+
+      if (!workData.description) {
+        return null;
+      }
+
+      if (typeof workData.description === 'string') {
+        return workData.description;
+      }
+
+      return workData.description.value ?? null;
+    } catch (error) {
+      const cause =
+        error instanceof TypeError && error.cause instanceof Error
+          ? ` (${error.cause.message})`
+          : '';
+      this.logger.warn(
+        `Failed to fetch book summary for "${title}" by "${author}" from Open Library: ${error instanceof Error ? error.message : String(error)}${cause}`,
+      );
+      return null;
+    }
   }
 
   async findAuthorEnrichment(name: string): Promise<AuthorEnrichment> {

--- a/src/infrastructure/repositories/book.repository.ts
+++ b/src/infrastructure/repositories/book.repository.ts
@@ -24,6 +24,7 @@ export class TypeOrmBookRepository implements IBookRepository {
 
   async findAll(limit?: number, offset?: number): Promise<Result<PaginationResult<Book[]>>> {
     const [bookEntities, total] = await this.repository.findAndCount({
+      order: { author: 'ASC', title: 'ASC' },
       take: limit,
       skip: offset,
     });
@@ -53,6 +54,8 @@ export class TypeOrmBookRepository implements IBookRepository {
       .innerJoin('book.bookShelves', 'shelf', 'shelf.id = :shelfId', {
         shelfId: bookShelf.id,
       })
+      .orderBy('book.author', 'ASC')
+      .addOrderBy('book.title', 'ASC')
       .take(limit)
       .skip(offset)
       .getManyAndCount();
@@ -102,6 +105,7 @@ export class TypeOrmBookRepository implements IBookRepository {
   async findByAuthor(author: string, limit?: number, offset?: number): Promise<Result<PaginationResult<Book[]>>> {
     const [bookEntities, total] = await this.repository.findAndCount({
       where: { author },
+      order: { title: 'ASC' },
       take: limit,
       skip: offset,
     });
@@ -117,6 +121,7 @@ export class TypeOrmBookRepository implements IBookRepository {
   async findFavorites(limit?: number, offset?: number): Promise<Result<PaginationResult<Book[]>>> {
     const [bookEntities, total] = await this.repository.findAndCount({
       where: { isFavorite: true },
+      order: { author: 'ASC', title: 'ASC' },
       take: limit,
       skip: offset,
     });
@@ -139,6 +144,8 @@ export class TypeOrmBookRepository implements IBookRepository {
     const [bookEntities, total] = await this.repository
       .createQueryBuilder('book')
       .where('LOWER(book.title) LIKE LOWER(:title)', { title: `%${title}%` })
+      .orderBy('book.author', 'ASC')
+      .addOrderBy('book.title', 'ASC')
       .limit(limit)
       .skip(offset)
       .getManyAndCount();
@@ -161,6 +168,8 @@ export class TypeOrmBookRepository implements IBookRepository {
       .createQueryBuilder('book')
       .where('LOWER(book.title) LIKE LOWER(:title)', { title: `%${title}%` })
       .andWhere('book.isFavorite = true')
+      .orderBy('book.author', 'ASC')
+      .addOrderBy('book.title', 'ASC')
       .limit(limit)
       .skip(offset)
       .getManyAndCount();
@@ -184,6 +193,7 @@ export class TypeOrmBookRepository implements IBookRepository {
       .createQueryBuilder('book')
       .where('book.author = :author', { author })
       .andWhere('LOWER(book.title) LIKE LOWER(:title)', { title: `%${title}%` })
+      .orderBy('book.title', 'ASC')
       .limit(limit)
       .skip(offset)
       .getManyAndCount();

--- a/src/modules/book.module.ts
+++ b/src/modules/book.module.ts
@@ -13,6 +13,8 @@ import { TypeOrmBookRepository } from 'src/infrastructure/repositories/book.repo
 import { BookController } from 'src/presentation/controllers/book.controller';
 import { AuthModule } from 'src/modules/auth.module';
 import { UsersModule } from 'src/modules/user.module';
+import { OpenLibraryGateway } from 'src/infrastructure/gateways/open-library.gateway';
+import { FetchBookSummaryUseCase } from 'src/application/usecases/book/fetch-book-summary.usecase';
 
 @Module({
   imports: [
@@ -35,10 +37,14 @@ import { UsersModule } from 'src/modules/user.module';
     GetFavoriteBooksUseCase,
     GetBookByIdUseCase,
     UpdateBookUseCase,
+    FetchBookSummaryUseCase,
     // ... other use cases
 
     // Mappers
     BookMapper,
+
+    // Gateways
+    OpenLibraryGateway,
   ],
   controllers: [BookController],
   exports: ['BookRepository'],

--- a/src/presentation/controllers/book.controller.ts
+++ b/src/presentation/controllers/book.controller.ts
@@ -35,6 +35,7 @@ import { DownloadBookUseCase } from 'src/application/usecases/book/download-book
 import { createReadStream, existsSync } from 'fs';
 import { basename } from 'path';
 import { Response } from 'express';
+import { FetchBookSummaryUseCase } from 'src/application/usecases/book/fetch-book-summary.usecase';
 
 @Controller('books')
 @UseInterceptors(MapResultInterceptor)
@@ -47,6 +48,7 @@ export class BookController {
     private readonly deleteBookUseCase: DeleteBookUseCase,
     private readonly updateBookUseCase: UpdateBookUseCase,
     private readonly downloadBookUseCase: DownloadBookUseCase,
+    private readonly fetchBookSummaryUseCase: FetchBookSummaryUseCase,
   ) {}
 
   private readonly logger = new Logger('BookController');
@@ -163,6 +165,12 @@ export class BookController {
       ...updateBookDto,
     };
     return this.updateBookUseCase.execute(updateBookRequest);
+  }
+
+  @Post(':id/fetch-summary')
+  @UseGuards(JwtAuthGuard)
+  fetchBookSummary(@Param('id') id: string) {
+    return this.fetchBookSummaryUseCase.execute({ id });
   }
 
   @Get(':id/download')

--- a/test/application/usecases/book/fetch-book-summary.usecase.spec.ts
+++ b/test/application/usecases/book/fetch-book-summary.usecase.spec.ts
@@ -1,0 +1,95 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { IBookRepository } from 'src/application/interfaces/book-repository';
+import { FetchBookSummaryUseCase } from 'src/application/usecases/book/fetch-book-summary.usecase';
+import { mock } from 'jest-mock-extended';
+import { mockBook } from 'test/mocks/bookMocks';
+import { Result, UnexpectedFailure } from 'src/core/result';
+import { OpenLibraryGateway } from 'src/infrastructure/gateways/open-library.gateway';
+import { BookNotFoundFailure } from 'src/domain/failures/book.failures';
+import Mocked = jest.Mocked;
+
+describe('FetchBookSummaryUseCase', () => {
+  let useCase: FetchBookSummaryUseCase;
+  let bookRepository: Mocked<IBookRepository>;
+  let openLibraryGateway: Mocked<OpenLibraryGateway>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FetchBookSummaryUseCase,
+        {
+          provide: 'BookRepository',
+          useValue: mock<IBookRepository>(),
+        },
+        {
+          provide: OpenLibraryGateway,
+          useValue: mock<OpenLibraryGateway>(),
+        },
+      ],
+    }).compile();
+
+    useCase = module.get<FetchBookSummaryUseCase>(FetchBookSummaryUseCase);
+    bookRepository = module.get('BookRepository');
+    openLibraryGateway = module.get(OpenLibraryGateway);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('Fetches and persists summary from Open Library', async () => {
+    bookRepository.findById.mockResolvedValueOnce(Result.ok(mockBook));
+    openLibraryGateway.findBookSummary.mockResolvedValueOnce(
+      'A fetched summary.',
+    );
+    bookRepository.update.mockResolvedValueOnce(
+      Result.ok({ ...mockBook, summary: 'A fetched summary.' }),
+    );
+
+    const result = await useCase.execute({ id: mockBook.id });
+
+    expect(result.isSuccess()).toBe(true);
+    expect(openLibraryGateway.findBookSummary).toHaveBeenCalledWith(
+      mockBook.title,
+      mockBook.author,
+    );
+    const updatedBook = bookRepository.update.mock.calls[0][1];
+    expect(updatedBook.summary).toBe('A fetched summary.');
+  });
+
+  test('Succeeds without updating summary when Open Library returns null', async () => {
+    bookRepository.findById.mockResolvedValueOnce(Result.ok(mockBook));
+    openLibraryGateway.findBookSummary.mockResolvedValueOnce(null);
+
+    const result = await useCase.execute({ id: mockBook.id });
+
+    expect(result.isSuccess()).toBe(true);
+    expect(bookRepository.update).not.toHaveBeenCalled();
+  });
+
+  test('Returns failure when book is not found', async () => {
+    bookRepository.findById.mockResolvedValueOnce(
+      Result.fail(new BookNotFoundFailure()),
+    );
+
+    const result = await useCase.execute({ id: 'nonexistent-id' });
+
+    expect(result.isFailure()).toBe(true);
+    expect(bookRepository.update).not.toHaveBeenCalled();
+    expect(openLibraryGateway.findBookSummary).not.toHaveBeenCalled();
+  });
+
+  test('Returns failure when repository update fails', async () => {
+    bookRepository.findById.mockResolvedValueOnce(Result.ok(mockBook));
+    openLibraryGateway.findBookSummary.mockResolvedValueOnce(
+      'A fetched summary.',
+    );
+    bookRepository.update.mockResolvedValueOnce(
+      Result.fail(new UnexpectedFailure('Database error')),
+    );
+
+    const result = await useCase.execute({ id: mockBook.id });
+
+    expect(result.isFailure()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Books' summaries are now automatically fetched from the [Open Library API](https://openlibrary.org/developers/api) when a book is uploaded, instead of being accepted as user input. A backfill endpoint is also provided for books uploaded before this change.

## Changes

### src/infrastructure/gateways/open-library.gateway.ts
- Added findBookSummary(title, author) method: searches /search.json, fetches /works/{key}.json, and extracts the description (handles both string and {type, value} object formats). Returns 
null gracefully on any API failure — book creation is never blocked by this call.
- Updated User-Agent to Homebranch (self-hosted e-book library; ryan.bezold@gmail.com) per [Open Library's usage policy](https://openlibrary.org/developers/api#usage), which requires a contact email for identified requests (3× rate limit).

### src/application/contracts/book/create-book-request.ts
- Removed summary field. Summaries are no longer accepted from the client on upload.

### src/application/usecases/book/create-book.usecase.ts
- Injects OpenLibraryGateway and calls findBookSummary after building the Book object, before persisting. If the gateway returns 
ull, the book is created without a summary.

### src/application/usecases/book/fetch-book-summary.usecase.ts *(new)*
- FetchBookSummaryUseCase: looks up the book by ID, fetches its summary from Open Library using the stored title and author, and updates it in the database. Skips the DB write entirely if Open Library returns null (no unnecessary update).

### src/presentation/controllers/book.controller.ts
- New endpoint: POST /books/:id/fetch-summary — triggers a summary fetch for any book. Useful for backfilling summaries on books uploaded before this feature.

### src/infrastructure/repositories/book.repository.ts
- Added ORDER BY author ASC, title ASC to all list-returning queries (findAll, findFavorites, findByAuthor, findByBookShelfId, searchByTitle, searchFavoritesByTitle, searchByAuthorAndTitle). This ensures sort order is stable and never shifts when a book's summary is updated.

### src/modules/book.module.ts
- Added OpenLibraryGateway and FetchBookSummaryUseCase to providers.

### Tests
- 	test/application/usecases/book/create-book.usecase.spec.ts: mocks OpenLibraryGateway, asserts summary is sourced from the gateway, tests graceful degradation when gateway returns 
null.
- 	test/application/usecases/book/fetch-book-summary.usecase.spec.ts *(new)*: covers successful fetch, null response skips DB update, book not found, and repository failure.
