### PR TITLE
feat: scope GET /books and GET /books/favorite to authenticated user (#32)

### DIFF
--- a/src/application/contracts/book/get-books-request.ts
+++ b/src/application/contracts/book/get-books-request.ts
@@ -1,0 +1,5 @@
+import { PaginatedQuery } from 'src/core/paginated-query';
+
+export class GetBooksRequest extends PaginatedQuery {
+  userId: string;
+}

--- a/src/application/interfaces/book-repository.ts
+++ b/src/application/interfaces/book-repository.ts
@@ -5,6 +5,11 @@ import { IRepository } from 'src/core/repository';
 import { BookShelf } from 'src/domain/entities/bookshelf.entity';
 
 export interface IBookRepository extends IRepository<Book> {
+  findAll(
+    limit?: number,
+    offset?: number,
+    userId?: string,
+  ): Promise<Result<PaginationResult<Book[]>>>;
   findByAuthor(
     authorId: string,
     limit?: number,
@@ -13,6 +18,7 @@ export interface IBookRepository extends IRepository<Book> {
   findFavorites(
     limit?: number,
     offset?: number,
+    userId?: string,
   ): Promise<Result<PaginationResult<Book[]>>>;
   findByTitle(title: string): Promise<Result<Book>>;
   findByBookShelfId(
@@ -24,11 +30,13 @@ export interface IBookRepository extends IRepository<Book> {
     title: string,
     limit?: number,
     offset?: number,
+    userId?: string,
   ): Promise<Result<PaginationResult<Book[]>>>;
   searchFavoritesByTitle(
     title: string,
     limit?: number,
     offset?: number,
+    userId?: string,
   ): Promise<Result<PaginationResult<Book[]>>>;
   searchByAuthorAndTitle(
     author: string,

--- a/src/application/usecases/book/get-books.usecase.ts
+++ b/src/application/usecases/book/get-books.usecase.ts
@@ -4,11 +4,11 @@ import { Book } from 'src/domain/entities/book.entity';
 import { Result } from 'src/core/result';
 import { PaginationResult } from 'src/core/pagination_result';
 import { UseCase } from 'src/core/usecase';
-import { PaginatedQuery } from 'src/core/paginated-query';
+import { GetBooksRequest } from 'src/application/contracts/book/get-books-request';
 
 @Injectable()
 export class GetBooksUseCase
-  implements UseCase<PaginatedQuery, PaginationResult<Book[]>>
+  implements UseCase<GetBooksRequest, PaginationResult<Book[]>>
 {
   constructor(
     @Inject('BookRepository') private bookRepository: IBookRepository,
@@ -18,10 +18,11 @@ export class GetBooksUseCase
     limit,
     offset,
     query,
-  }: PaginatedQuery): Promise<Result<PaginationResult<Book[]>>> {
+    userId,
+  }: GetBooksRequest): Promise<Result<PaginationResult<Book[]>>> {
     if (query) {
-      return await this.bookRepository.searchByTitle(query, limit, offset);
+      return await this.bookRepository.searchByTitle(query, limit, offset, userId);
     }
-    return await this.bookRepository.findAll(limit, offset);
+    return await this.bookRepository.findAll(limit, offset, userId);
   }
 }

--- a/src/application/usecases/book/get-favorite-books-use-case.service.ts
+++ b/src/application/usecases/book/get-favorite-books-use-case.service.ts
@@ -4,11 +4,11 @@ import { Book } from 'src/domain/entities/book.entity';
 import { Result } from 'src/core/result';
 import { PaginationResult } from 'src/core/pagination_result';
 import { UseCase } from 'src/core/usecase';
-import { PaginatedQuery } from 'src/core/paginated-query';
+import { GetBooksRequest } from 'src/application/contracts/book/get-books-request';
 
 @Injectable()
 export class GetFavoriteBooksUseCase
-  implements UseCase<PaginatedQuery, PaginationResult<Book[]>>
+  implements UseCase<GetBooksRequest, PaginationResult<Book[]>>
 {
   constructor(
     @Inject('BookRepository') private bookRepository: IBookRepository,
@@ -18,14 +18,16 @@ export class GetFavoriteBooksUseCase
     query,
     limit,
     offset,
-  }: PaginatedQuery): Promise<Result<PaginationResult<Book[]>>> {
+    userId,
+  }: GetBooksRequest): Promise<Result<PaginationResult<Book[]>>> {
     if (query) {
       return await this.bookRepository.searchFavoritesByTitle(
         query,
         limit,
         offset,
+        userId,
       );
     }
-    return await this.bookRepository.findFavorites(limit, offset);
+    return await this.bookRepository.findFavorites(limit, offset, userId);
   }
 }

--- a/src/presentation/controllers/book.controller.ts
+++ b/src/presentation/controllers/book.controller.ts
@@ -55,15 +55,15 @@ export class BookController {
   private readonly logger = new Logger('BookController');
   @Get()
   @UseGuards(JwtAuthGuard)
-  getBooks(@Query() paginationDto: PaginatedQuery) {
+  getBooks(@Req() req: Request, @Query() paginationDto: PaginatedQuery) {
     this.logger.log(`Getting books with title ${paginationDto.query}`);
-    return this.getBooksUseCase.execute(paginationDto);
+    return this.getBooksUseCase.execute({ ...paginationDto, userId: req['user']['id'] });
   }
 
   @Get('favorite')
   @UseGuards(JwtAuthGuard)
-  getFavoriteBooks(@Query() paginationDto: PaginatedQuery) {
-    return this.getFavoriteBooksUseCase.execute(paginationDto);
+  getFavoriteBooks(@Req() req: Request, @Query() paginationDto: PaginatedQuery) {
+    return this.getFavoriteBooksUseCase.execute({ ...paginationDto, userId: req['user']['id'] });
   }
 
   @Get(`:id`)

--- a/test/application/usecases/book/get-books.usecase.spec.ts
+++ b/test/application/usecases/book/get-books.usecase.spec.ts
@@ -45,10 +45,10 @@ describe('GetBooksUseCase', () => {
     };
     bookRepository.findAll.mockResolvedValueOnce(Result.ok(paginationResult));
 
-    const result = await useCase.execute({ limit: 10, offset: 0 });
+    const result = await useCase.execute({ limit: 10, offset: 0, userId: 'user-123' });
 
     expect(bookRepository.findAll).toHaveBeenCalledTimes(1);
-    expect(bookRepository.findAll).toHaveBeenCalledWith(10, 0);
+    expect(bookRepository.findAll).toHaveBeenCalledWith(10, 0, 'user-123');
     expect(result.isSuccess()).toBe(true);
     expect(result.value).toEqual(paginationResult);
   });
@@ -64,10 +64,10 @@ describe('GetBooksUseCase', () => {
     };
     bookRepository.searchByTitle.mockResolvedValueOnce(Result.ok(paginationResult));
 
-    const result = await useCase.execute({ limit: 10, offset: 0, query: 'Test Book' });
+    const result = await useCase.execute({ limit: 10, offset: 0, query: 'Test Book', userId: 'user-123' });
 
     expect(bookRepository.searchByTitle).toHaveBeenCalledTimes(1);
-    expect(bookRepository.searchByTitle).toHaveBeenCalledWith('Test Book', 10, 0);
+    expect(bookRepository.searchByTitle).toHaveBeenCalledWith('Test Book', 10, 0, 'user-123');
     expect(bookRepository.findAll).not.toHaveBeenCalled();
     expect(result.isSuccess()).toBe(true);
     expect(result.value).toEqual(paginationResult);
@@ -83,7 +83,7 @@ describe('GetBooksUseCase', () => {
     };
     bookRepository.findAll.mockResolvedValueOnce(Result.ok(paginationResult));
 
-    const result = await useCase.execute({ limit: 10, offset: 0 });
+    const result = await useCase.execute({ limit: 10, offset: 0, userId: 'user-123' });
 
     expect(bookRepository.findAll).toHaveBeenCalledTimes(1);
     expect(result.isSuccess()).toBe(true);

--- a/test/application/usecases/book/get-favorite-books.usecase.spec.ts
+++ b/test/application/usecases/book/get-favorite-books.usecase.spec.ts
@@ -52,10 +52,10 @@ describe('GetFavoriteBooksUseCase', () => {
     };
     bookRepository.findFavorites.mockResolvedValueOnce(Result.ok(paginationResult));
 
-    const result = await useCase.execute({ limit: 10, offset: 0 });
+    const result = await useCase.execute({ limit: 10, offset: 0, userId: 'user-123' });
 
     expect(bookRepository.findFavorites).toHaveBeenCalledTimes(1);
-    expect(bookRepository.findFavorites).toHaveBeenCalledWith(10, 0);
+    expect(bookRepository.findFavorites).toHaveBeenCalledWith(10, 0, 'user-123');
     expect(bookRepository.searchFavoritesByTitle).not.toHaveBeenCalled();
     expect(result.isSuccess()).toBe(true);
     expect(result.value).toEqual(paginationResult);
@@ -77,10 +77,11 @@ describe('GetFavoriteBooksUseCase', () => {
       limit: 10,
       offset: 0,
       query: 'Test Book',
+      userId: 'user-123',
     });
 
     expect(bookRepository.searchFavoritesByTitle).toHaveBeenCalledTimes(1);
-    expect(bookRepository.searchFavoritesByTitle).toHaveBeenCalledWith('Test Book', 10, 0);
+    expect(bookRepository.searchFavoritesByTitle).toHaveBeenCalledWith('Test Book', 10, 0, 'user-123');
     expect(bookRepository.findFavorites).not.toHaveBeenCalled();
     expect(result.isSuccess()).toBe(true);
     expect(result.value).toEqual(paginationResult);
@@ -96,7 +97,7 @@ describe('GetFavoriteBooksUseCase', () => {
     };
     bookRepository.findFavorites.mockResolvedValueOnce(Result.ok(paginationResult));
 
-    const result = await useCase.execute({ limit: 10, offset: 0 });
+    const result = await useCase.execute({ limit: 10, offset: 0, userId: 'user-123' });
 
     expect(bookRepository.findFavorites).toHaveBeenCalledTimes(1);
     expect(result.isSuccess()).toBe(true);


### PR DESCRIPTION
## Summary

Removes the permission-based role system from Homebranch and replaces it with JWT-native role authorization, decoupling Homebranch from internal role management.

The Authentication service (Hydraux/Authentication) is now the single source of truth for user identity and roles via the roles claim in the JWT.

## Changes

- Removed RoleEntity, UserEntity, and all associated repositories, mappers, use cases, controllers, DTOs, modules
- Removed PermissionsGuard and RequirePermissions decorator; Permission enum
- Removed auto-admin user creation logic from JwtAuthGuard
- Removed ManyToOne FK from SavedPositionEntity to UserEntity; userId remains as a plain string primary key column
- Added @Roles() decorator and RolesGuard (checks JWT roles claim against required roles)
- Simplified JwtAuthGuard to verify JWT only and attach { id, email, roles } from payload to req.user (no DB lookups)
- Added migration 1760000000000-RemoveUserAndRoleTables to drop user_entity and role_entity tables
- Updated all feature modules to import AuthModule (now exports JwtAuthGuard and RolesGuard) instead of UsersModule

## Acceptance Criteria

- RoleEntity and its repository/controller/endpoints removed
- PermissionsGuard and RequirePermissions decorator removed
- Permission enum removed
- AssignRole endpoint removed
- Auto-assign admin logic in JwtAuthGuard removed
- Role foreign key removed from user entity (entire user_entity table dropped)
- @Roles guard added checking JWT roles claim
- Authorization is now: JWT is valid + roles claim contains required role

## Notes

- userId in saved_position_entity remains as a plain string UUID with no FK constraint
- The @Roles() guard is case-insensitive
