### PR TITLE
feat: guard DELETE /books/:id by book ownership (#33)

### DIFF
--- a/src/application/contracts/book/delete-book-request.ts
+++ b/src/application/contracts/book/delete-book-request.ts
@@ -3,4 +3,7 @@ import { IsUUID } from 'class-validator';
 export class DeleteBookRequest {
   @IsUUID()
   id: string;
+
+  requestingUserId: string;
+  requestingUserRole: string;
 }

--- a/src/application/usecases/book/delete-book.usecase.ts
+++ b/src/application/usecases/book/delete-book.usecase.ts
@@ -4,6 +4,7 @@ import { DeleteBookRequest } from '../../contracts/book/delete-book-request';
 import { Book } from 'src/domain/entities/book.entity';
 import { Result } from 'src/core/result';
 import { UseCase } from 'src/core/usecase';
+import { DeleteBookForbiddenFailure } from 'src/domain/failures/book.failures';
 
 @Injectable()
 export class DeleteBookUseCase implements UseCase<DeleteBookRequest, Book> {
@@ -11,7 +12,23 @@ export class DeleteBookUseCase implements UseCase<DeleteBookRequest, Book> {
     @Inject('BookRepository') private bookRepository: IBookRepository,
   ) {}
 
-  async execute({ id }: DeleteBookRequest): Promise<Result<Book>> {
+  async execute({
+    id,
+    requestingUserId,
+    requestingUserRole,
+  }: DeleteBookRequest): Promise<Result<Book>> {
+    const bookResult = await this.bookRepository.findById(id);
+    if (!bookResult.isSuccess()) return bookResult;
+
+    const book = bookResult.value;
+    if (
+      requestingUserRole !== 'ADMIN' &&
+      book.uploadedByUserId !== undefined &&
+      book.uploadedByUserId !== requestingUserId
+    ) {
+      return Result.fail(new DeleteBookForbiddenFailure());
+    }
+
     return await this.bookRepository.delete(id);
   }
 }

--- a/src/domain/failures/book.failures.ts
+++ b/src/domain/failures/book.failures.ts
@@ -5,3 +5,9 @@ export class BookNotFoundFailure extends Failure {
     super('BOOK_NOT_FOUND', 'Book not found');
   }
 }
+
+export class DeleteBookForbiddenFailure extends Failure {
+  constructor() {
+    super('FORBIDDEN', 'Only the uploader or an admin can delete this book');
+  }
+}

--- a/src/presentation/controllers/book.controller.ts
+++ b/src/presentation/controllers/book.controller.ts
@@ -152,9 +152,11 @@ export class BookController {
 
   @Delete(`:id`)
   @UseGuards(JwtAuthGuard)
-  deleteBook(@Param('id') id: string) {
+  deleteBook(@Req() request: Request, @Param('id') id: string) {
     const deleteBookRequest: DeleteBookRequest = {
       id,
+      requestingUserId: request['user'].id,
+      requestingUserRole: request['user'].roles?.includes('ADMIN') ? 'ADMIN' : 'USER',
     };
     return this.deleteBookUseCase.execute(deleteBookRequest);
   }

--- a/test/application/usecases/book/delete-book.usecase.spec.ts
+++ b/test/application/usecases/book/delete-book.usecase.spec.ts
@@ -2,9 +2,12 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { IBookRepository } from 'src/application/interfaces/book-repository';
 import { DeleteBookUseCase } from 'src/application/usecases/book/delete-book.usecase';
 import { mock } from 'jest-mock-extended';
-import { mockBook } from 'test/mocks/bookMocks';
+import { mockBook, mockBookFavorite } from 'test/mocks/bookMocks';
 import { Result } from 'src/core/result';
-import { BookNotFoundFailure } from 'src/domain/failures/book.failures';
+import {
+  BookNotFoundFailure,
+  DeleteBookForbiddenFailure,
+} from 'src/domain/failures/book.failures';
 import Mocked = jest.Mocked;
 
 describe('DeleteBookUseCase', () => {
@@ -12,6 +15,7 @@ describe('DeleteBookUseCase', () => {
   let bookRepository: Mocked<IBookRepository>;
 
   const bookNotFoundFailure = new BookNotFoundFailure();
+  const deleteBookForbiddenFailure = new DeleteBookForbiddenFailure();
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -32,24 +36,81 @@ describe('DeleteBookUseCase', () => {
     jest.clearAllMocks();
   });
 
-  test('Successfully deletes a book', async () => {
+  test('Successfully deletes a book when requested by the owner', async () => {
+    bookRepository.findById.mockResolvedValueOnce(Result.ok(mockBook));
     bookRepository.delete.mockResolvedValueOnce(Result.ok(mockBook));
 
-    const result = await useCase.execute({ id: mockBook.id });
+    const result = await useCase.execute({
+      id: mockBook.id,
+      requestingUserId: mockBook.uploadedByUserId!,
+      requestingUserRole: 'USER',
+    });
 
+    expect(bookRepository.findById).toHaveBeenCalledTimes(1);
+    expect(bookRepository.findById).toHaveBeenCalledWith(mockBook.id);
     expect(bookRepository.delete).toHaveBeenCalledTimes(1);
     expect(bookRepository.delete).toHaveBeenCalledWith(mockBook.id);
     expect(result.isSuccess()).toBe(true);
     expect(result.value).toEqual(mockBook);
   });
 
-  test('Fails when book not found', async () => {
-    bookRepository.delete.mockResolvedValueOnce(Result.fail(bookNotFoundFailure));
+  test('Successfully deletes a book when requested by an admin', async () => {
+    bookRepository.findById.mockResolvedValueOnce(Result.ok(mockBook));
+    bookRepository.delete.mockResolvedValueOnce(Result.ok(mockBook));
 
-    const result = await useCase.execute({ id: 'non-existent-id' });
+    const result = await useCase.execute({
+      id: mockBook.id,
+      requestingUserId: 'different-user-id',
+      requestingUserRole: 'ADMIN',
+    });
 
     expect(bookRepository.delete).toHaveBeenCalledTimes(1);
-    expect(bookRepository.delete).toHaveBeenCalledWith('non-existent-id');
+    expect(result.isSuccess()).toBe(true);
+  });
+
+  test('Fails with forbidden when non-owner non-admin requests deletion', async () => {
+    bookRepository.findById.mockResolvedValueOnce(Result.ok(mockBook));
+
+    const result = await useCase.execute({
+      id: mockBook.id,
+      requestingUserId: 'different-user-id',
+      requestingUserRole: 'USER',
+    });
+
+    expect(bookRepository.findById).toHaveBeenCalledTimes(1);
+    expect(bookRepository.delete).not.toHaveBeenCalled();
+    expect(result.isFailure()).toBe(true);
+    expect(result.failure).toEqual(deleteBookForbiddenFailure);
+  });
+
+  test('Successfully deletes a book without an owner when requested by any user', async () => {
+    bookRepository.findById.mockResolvedValueOnce(Result.ok(mockBookFavorite));
+    bookRepository.delete.mockResolvedValueOnce(Result.ok(mockBookFavorite));
+
+    const result = await useCase.execute({
+      id: mockBookFavorite.id,
+      requestingUserId: 'any-user-id',
+      requestingUserRole: 'USER',
+    });
+
+    expect(bookRepository.delete).toHaveBeenCalledTimes(1);
+    expect(result.isSuccess()).toBe(true);
+  });
+
+  test('Fails when book not found', async () => {
+    bookRepository.findById.mockResolvedValueOnce(
+      Result.fail(bookNotFoundFailure),
+    );
+
+    const result = await useCase.execute({
+      id: 'non-existent-id',
+      requestingUserId: 'user-123',
+      requestingUserRole: 'USER',
+    });
+
+    expect(bookRepository.findById).toHaveBeenCalledTimes(1);
+    expect(bookRepository.findById).toHaveBeenCalledWith('non-existent-id');
+    expect(bookRepository.delete).not.toHaveBeenCalled();
     expect(result.isFailure()).toBe(true);
     expect(result.failure).toEqual(bookNotFoundFailure);
   });


### PR DESCRIPTION
## Summary

Guards `DELETE /books/:id` so only the uploader or an ADMIN can delete a book. The JWT-authenticated user's identity is extracted from the request and passed to the use case, which verifies ownership before delegating to the repository.

## Changes

- **`src/domain/failures/book.failures.ts`** — Added `DeleteBookForbiddenFailure` (code: `FORBIDDEN`, maps to HTTP 403)
- **`src/application/contracts/book/delete-book-request.ts`** — Added `requestingUserId` and `requestingUserRole` fields
- **`src/application/usecases/book/delete-book.usecase.ts`** — Fetch book first, check ownership; allow if ADMIN or matching `uploadedByUserId`; books without `uploadedByUserId` (legacy) are deletable by any user
- **`src/presentation/controllers/book.controller.ts`** — Extract user id and role from `request['user']`; fixed role extraction to use `roles: string[]` array (not `role.name`)
- **`test/application/usecases/book/delete-book.usecase.spec.ts`** — Updated tests covering owner, admin bypass, forbidden, no-owner legacy, and not-found cases

## Acceptance Criteria

✅ Non-owner, non-admin users receive HTTP 403 when attempting to delete a book they did not upload  
✅ The uploader of a book can delete it  
✅ An ADMIN can delete any book regardless of ownership  
✅ Books with no `uploadedByUserId` can be deleted by any authenticated user (permissive legacy policy)  
✅ A 404 is returned when the book does not exist  

Closes #33
